### PR TITLE
Updated: GH Actions & Dependencies

### DIFF
--- a/.github/workflows/DeployMkDocs.yml
+++ b/.github/workflows/DeployMkDocs.yml
@@ -21,7 +21,7 @@ jobs:
       
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Deploy MkDocs
       - name: Deploy MkDocs

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -25,7 +25,7 @@ jobs:
         shell: pwsh
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         
@@ -36,21 +36,23 @@ jobs:
         echo "Is Release?: $env:IS_RELEASE"
         echo "Release Tag: $env:RELEASE_TAG"
     
-    - name: Setup .NET Core SDK (3.1)
-      uses: actions/setup-dotnet@v1.8.2
+    - name: Setup .NET Core SDK (3.1.x)
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 3.1.x
-    - name: Setup .NET Core SDK (5.0)
-      uses: actions/setup-dotnet@v1.8.2
+
+    - name: Setup .NET Core SDK (5.0.x)
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 5.0.x
+    
     - name: Setup .NET Core SDK (6.0.x)
-      uses: actions/setup-dotnet@v1.8.2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
         
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: '14'
         
@@ -95,7 +97,7 @@ jobs:
         }
          
     - name: Upload NuGet Artifacts
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: NuGet Packages
@@ -104,7 +106,7 @@ jobs:
         retention-days: 0
         
     - name: Upload Changelog Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Changelog
@@ -113,7 +115,7 @@ jobs:
         retention-days: 0
     
     - name: Upload Tools Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: Tools
@@ -122,7 +124,7 @@ jobs:
         retention-days: 0
     
     - name: Upload to GitHub Releases
-      uses: softprops/action-gh-release@v0.1.14
+      uses: softprops/action-gh-release@v2
       if: env.IS_RELEASE == 'true'
       with:
         # Path to load note-worthy description of changes in release from

--- a/Sewer56.Update/Extractors/Sewer56.Update.Extractors.SevenZipSharp/Sewer56.Update.Extractors.SevenZipSharp.csproj
+++ b/Sewer56.Update/Extractors/Sewer56.Update.Extractors.SevenZipSharp/Sewer56.Update.Extractors.SevenZipSharp.csproj
@@ -12,7 +12,7 @@
     <RepositoryType>https://github.com/Sewer56/Update</RepositoryType>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Squid-Box.SevenZipSharp.Lite" Version="1.5.0.366" />
+    <PackageReference Include="Squid-Box.SevenZipSharp.Lite" Version="1.6.2.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sewer56.Update/Extractors/Sewer56.Update.Extractors.SharpCompress/Sewer56.Update.Extractors.SharpCompress.csproj
+++ b/Sewer56.Update/Extractors/Sewer56.Update.Extractors.SharpCompress/Sewer56.Update.Extractors.SharpCompress.csproj
@@ -12,11 +12,11 @@
     <PackageProjectUrl>https://github.com/Sewer56/Update</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Sewer56/Update</RepositoryUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpCompress" Version="0.30.0" />
+    <PackageReference Include="SharpCompress" Version="0.31.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sewer56.Update/Resolvers/Sewer56.Update.Resolvers.GameBanana/Sewer56.Update.Resolvers.GameBanana.csproj
+++ b/Sewer56.Update/Resolvers/Sewer56.Update.Resolvers.GameBanana/Sewer56.Update.Resolvers.GameBanana.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/Sewer56/Update</RepositoryUrl>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/Sewer56.Update/Resolvers/Sewer56.Update.Resolvers.GitHub/Sewer56.Update.Resolvers.GitHub.csproj
+++ b/Sewer56.Update/Resolvers/Sewer56.Update.Resolvers.GitHub/Sewer56.Update.Resolvers.GitHub.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1; net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/Sewer56/Update</RepositoryUrl>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.5.1</Version>
+    <Version>1.5.2</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/Sewer56.Update/Resolvers/Sewer56.Update.Resolvers.NuGet/Sewer56.Update.Resolvers.NuGet.csproj
+++ b/Sewer56.Update/Resolvers/Sewer56.Update.Resolvers.NuGet/Sewer56.Update.Resolvers.NuGet.csproj
@@ -12,13 +12,12 @@
     <RepositoryUrl>https://github.com/Sewer56/Update</RepositoryUrl>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Packaging" Version="6.3.1" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="6.3.1" />
-    <PackageReference Include="NuGet.Protocol" Version="6.3.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.11.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sewer56.Update/Sewer56.Update.Packaging/Sewer56.Update.Packaging.csproj
+++ b/Sewer56.Update/Sewer56.Update.Packaging/Sewer56.Update.Packaging.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
@@ -17,7 +17,7 @@ Contains the necessary component for creating packages and releases.</Descriptio
     <RepositoryUrl>https://github.com/Sewer56/Update</RepositoryUrl>
     <PackageTags>update;netcore;dotnet;packaging</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
@@ -33,7 +33,7 @@ Contains the necessary component for creating packages and releases.</Descriptio
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Versioning" Version="5.11.0" />
+    <PackageReference Include="NuGet.Versioning" Version="6.11.0" />
     <PackageReference Include="Sewer56.DeltaPatchGenerator" Version="2.0.1" />
   </ItemGroup>
 

--- a/Sewer56.Update/Sewer56.Update.Tests/Sewer56.Update.Tests.csproj
+++ b/Sewer56.Update/Sewer56.Update.Tests/Sewer56.Update.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.3.3" />
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="Polly" Version="7.2.2" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+	  <PackageReference Include="CliWrap" Version="3.3.3" />
+	  <PackageReference Include="FluentAssertions" Version="6.1.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+	  <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+	  <PackageReference Include="Polly" Version="7.2.2" />
+	  <PackageReference Include="xunit" Version="2.4.0" />
+	  <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+	  <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sewer56.Update/Sewer56.Update.Tool/Sewer56.Update.Tool.csproj
+++ b/Sewer56.Update/Sewer56.Update.Tool/Sewer56.Update.Tool.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="FluentValidation" Version="10.3.4" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="FluentValidation" Version="11.9.2" />
     <PackageReference Include="Mapster" Version="7.3.0" />
-    <PackageReference Include="ShellProgressBar" Version="5.1.0" />
+    <PackageReference Include="ShellProgressBar" Version="5.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sewer56.Update/Sewer56.Update/Sewer56.Update.csproj
+++ b/Sewer56.Update/Sewer56.Update/Sewer56.Update.csproj
@@ -19,7 +19,7 @@ This framework is a hard fork of Onova.</Description>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Authors>Sewer56, Tyrrrz</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <IsTrimmable>true</IsTrimmable>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
Upgrade GH Actions
* Upgrade all Microsoft actions to v4
* Upgrade other actions to latest stable releases
* Bump to 4.0.2 for Sewer56.Update
* Bump any subprojects with dependency changes